### PR TITLE
mostrar-redes-dinamicamente/ot289-81

### DIFF
--- a/src/features/Footer/Footer.js
+++ b/src/features/Footer/Footer.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { useState, useEffect } from 'react';
 
 //Social Icons
 import { Facebook, Instagram, Twitter } from 'react-bootstrap-icons'
@@ -23,7 +24,7 @@ const links = [
     }
 ]
 
-const socialLinks = [
+/* const socialLinks = [
     {
         name: 'Instagram',
         url: 'https://instagram.com'
@@ -36,9 +37,20 @@ const socialLinks = [
         name: 'Twitter',
         url: 'https://twitter.com'
     }
-]
+] */
 
 const Footer = () => {
+
+    const [data, setData] = useState({})
+
+    useEffect(() => {
+        fetch('http://localhost:3001/organizations/1/public')
+            .then(response => response.json())
+            .then(data => setData(data.socialLinks))
+    }, []);
+
+    console.log(data)
+
     const Logo = () => {
         return (
             <div className={`${styles.box} ${styles.logoContainer}`}>
@@ -68,16 +80,16 @@ const Footer = () => {
 
     //Social media icon
     //Add more if needed (first import it from 'react-bootstrap-icons')
-    const SocialIcon = ({socialName, size}) => {
-        switch(socialName) {
+    const SocialIcon = ({ socialName, size }) => {
+        switch (socialName) {
             case 'Facebook':
                 return <Facebook size={size} className={styles.icon} />
             case 'Instagram':
                 return <Instagram size={size} className={styles.icon} />
             case 'Twitter':
                 return <Twitter size={size} className={styles.icon} />
-            default: 
-            return null
+            default:
+                return null
         }
     }
 
@@ -85,9 +97,9 @@ const Footer = () => {
         return (
             <div className={`${styles.box} ${styles.socialLinks}`}>
                 <h3>Nuestras redes</h3>
-                {socialLinks.length > 0 && (
+                {data.length > 0 && (
                     <ul>
-                        {socialLinks.map((social, index) => {
+                        {data.map((social, index) => {
                             return (
                                 <li key={`social-${index}`}>
                                     <a href={social.url} target="_blank" rel="noopener noreferrer" className={styles.socialLink}>

--- a/src/features/Footer/Footer.js
+++ b/src/features/Footer/Footer.js
@@ -41,15 +41,15 @@ const links = [
 
 const Footer = () => {
 
-    const [data, setData] = useState({})
+    const [socialLinks, setSocialLinks] = useState([])
 
     useEffect(() => {
         fetch('http://localhost:3001/organizations/1/public')
             .then(response => response.json())
-            .then(data => setData(data.socialLinks))
+            .then(data => setSocialLinks(data.socialLinks))
     }, []);
 
-    console.log(data)
+    console.log(socialLinks)
 
     const Logo = () => {
         return (
@@ -97,9 +97,9 @@ const Footer = () => {
         return (
             <div className={`${styles.box} ${styles.socialLinks}`}>
                 <h3>Nuestras redes</h3>
-                {data.length > 0 && (
+                {socialLinks.length > 0 && (
                     <ul>
-                        {data.map((social, index) => {
+                        {socialLinks.map((social, index) => {
                             return (
                                 <li key={`social-${index}`}>
                                     <a href={social.url} target="_blank" rel="noopener noreferrer" className={styles.socialLink}>


### PR DESCRIPTION
https://alkemy-labs.atlassian.net/browse/OT289-81

summary:
the footer element contained an array 'socialLinks' with hardcoded urls for Facebook, twitter and instagram. it was commented out and replaced its use with a fetch from an endpoint containing the same information, then used to do a .map ( ) and dynamically show social media urls

evidence: (looks the same as before, has a console.log at the bottom to displayed fetched data)
<img width="634" alt="Screen Shot 2022-10-04 at 19 21 10" src="https://user-images.githubusercontent.com/99274893/193941769-1a9dcb66-9e0f-4946-b965-5b3028404c52.png">


